### PR TITLE
Support Keycloak 19.x logout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "keycloak-hapi",
   "version": "4.1.1",
+  "type": "module",
   "description": "Integration of Keycloak Authorization Server with HapiJS",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Replaced `redirct_uri` query parameter with `post_logout_redirect_uri` and `id_token_hint` as required in Keycloak 19.x